### PR TITLE
Improve Vector initialization times from Vec references

### DIFF
--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -1793,13 +1793,7 @@ where
             )));
         }
 
-        match t_vec.clone().try_into() {
-            Ok(s) => Ok(Self { components: s }),
-            Err(err) => Err(VectorError::TryFromVecError(format!(
-                "failed to cast Vec to Vector type: {:?}",
-                err
-            ))),
-        }
+        Self::try_from(&t_vec[..])
     }
 }
 


### PR DESCRIPTION
Refactors the implementation of initialization from std lib Vec references to achieve a ~10-fold improvement in initialization times with three-dimensional i32 and f64 data.

Benched with:

- MBP 16-inch 2021
- Apple M1 Max chip
- 32GB RAM
- rustc 1.57.0 (f1edd0429 2021-11-29)
- Criterion 0.3.5

using the following criterion benchmark tests:

```rust
fn criterion_benchmark(c: &mut Criterion) {
    let vec = vec![1, 2, 3];
    c.bench_function("Vector Initialization: i32 3D from Vec ref", |b| {
        b.iter(|| Vector::<i32, 3>::try_from(&vec).unwrap())
    });
}

fn criterion_benchmark(c: &mut Criterion) {
    let vec = vec![1.0_f64, 2.0_f64, 3.0_f64];
    c.bench_function("Vector Initialization: f64 3D from Vec ref", |b| {
        b.iter(|| Vector::<f64, 3>::try_from(&vec).unwrap())
    });
}
```

## Results

### i32 Vec ref (current)

```
Vector Initialization: i32 3D from Vec ref
                        time:   [23.690 ns 23.835 ns 23.972 ns]
                        change: [-2.8939% -2.3926% -1.9352%] (p = 0.00 < 0.05)
                        Performance has improved.
```


### i32 Vec ref (refactored)

```
Vector Initialization: i32 3D from Vec ref
                        time:   [2.0281 ns 2.0334 ns 2.0403 ns]
                        change: [-91.445% -91.405% -91.367%] (p = 0.00 < 0.05)
                        Performance has improved.
```


### f64 Vec ref (current)

```
Vector Initialization: f64 3D from Vec ref
                        time:   [24.214 ns 24.277 ns 24.357 ns]
                        change: [+0.0042% +0.2908% +0.5961%] (p = 0.05 < 0.05)
                        Change within noise threshold.
```


### f64 Vec ref (refactored)

```
Vector Initialization: f64 3D from Vec ref
                        time:   [2.2640 ns 2.2693 ns 2.2763 ns]
                        change: [-90.677% -90.647% -90.618%] (p = 0.00 < 0.05)
                        Performance has improved.
```