### PR TITLE
Implement parallel feature support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,21 @@ exclude = [
 [dependencies]
 approx = "0.5.0"
 num = "0.4.0"
+# optional dependencies
+rayon = { version = "1.5.1", optional = true }
 
+[features]
+parallel = ["rayon"]
 
 [dev-dependencies]
 criterion = "0.3"
 pretty_assertions = "1.0.0"
 tempdir = "0.3.7"
 
-
 [[bench]]
 name = "vectora_benchmarks"
 harness = false
+
+[package.metadata.docs.rs]
+# Whether to pass `--all-features` to Cargo (default: false)
+all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,10 +106,12 @@
 //!
 //! ```yaml
 //! [dependencies]
-//! vectora = { version = "0.7.0", features = ["parallel"] }
+//! vectora = { version = "VERSION_NUMBER", features = ["parallel"] }
 //! ```
 //!
-//! Conditional compilation and dependency installation are available for the following features:
+//! Replace `VERSION_NUMBER` in the example above with the vectora crate version number.
+//!
+//! Conditional compilation and optional dependency installation are available for the following features:
 //!
 //! - **`parallel`**: Installs an optional [rayon crate](https://docs.rs/crate/rayon/latest) dependency and broadens the [`Vector`] API with
 //! parallel iterator and parallel slice support. This feature includes implementations of `Vector::into_par_iter`, `Vector::par_iter`,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 //! - [License](#license)
 //! - [Getting Started](#getting-started)
 //!     - [Add Vectora to Your Project](#add-vectora-to-your-project)
+//!     - [Optional Crate Features](#optional-crate-features)
 //!     - [Numeric Type Support](#numeric-type-support)
 //!     - [Initialization](#initialization)
 //!     - [Numeric Type Casts](#numeric-type-casts)
@@ -98,6 +99,25 @@
 //! ```
 //! use vectora::Vector;
 //! ```
+//!
+//! ## Optional Crate Features
+//!
+//! Optional features are defined in your `Cargo.toml` configuration file:
+//!
+//! ```yaml
+//! [dependencies]
+//! vectora = { version = "0.7.0", features = ["parallel"] }
+//! ```
+//!
+//! Conditional compilation and dependency installation are available for the following features:
+//!
+//! - **`parallel`**: Installs an optional [rayon crate](https://docs.rs/crate/rayon/latest) dependency and broadens the [`Vector`] API with
+//! parallel iterator and parallel slice support. This feature includes implementations of `Vector::into_par_iter`, `Vector::par_iter`,
+//! `Vector::par_iter_mut`, `Vector::as_parallel_slice`, and `Vector::as_parallel_slice_mut` methods with support for the rayon trait-defined
+//! [parallel iterator](https://docs.rs/rayon/latest/rayon/iter/trait.ParallelIterator.html#provided-methods),
+//! [immutable parallel slice](https://docs.rs/rayon/latest/rayon/slice/trait.ParallelSlice.html), and
+//! [mutable parallel slice](https://docs.rs/rayon/latest/rayon/slice/trait.ParallelSliceMut.html) APIs.
+//!
 //!
 //! ## Numeric Type Support
 //!
@@ -539,6 +559,17 @@
 //!     // do things
 //! }
 //! ```
+//!
+//! ### Parallel iteration (Optional crate feature)
+//!
+//! *Optional* rayon parallel iterator support may be installed with the vectora crate
+//! `parallel` feature.  With activation of this feature, you may use the `Vector::into_par_iter`,
+//! `Vector::par_iter`, or `Vector::par_iter_mut` methods to create a parallel iterator over owned
+//! [`Vector`] scalars or scalar references.  The `parallel` feature provides access to the
+//! [rayon parallel iterator API](https://docs.rs/rayon/latest/rayon/iter/trait.ParallelIterator.html#provided-methods).
+//!
+//! See the [Optional Crate Features](#optional-crate-features) section above for
+//! installation instructions and refer to the [`Vector`] API docs for additional details.
 //!
 //! ## Vector Arithmetic
 //!

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -13,9 +13,6 @@ use approx::{AbsDiffEq, Relative, RelativeEq, UlpsEq};
 use num::{Complex, Float, Num, ToPrimitive};
 
 #[cfg(feature = "parallel")]
-// clippy with --all-features does not seem to appropriately detect
-// use of the following imported trait implmentations so we mark with
-// allow unused_imports
 #[allow(unused_imports)]
 use rayon::iter::{
     IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,


### PR DESCRIPTION
Closes #65

Adds an optional "parallel" feature and optional rayon dependency that is installed when the feature is configured in a build.

Implements the rayon `IntoParallelIterator` trait on the `Vector` type.  With this implementation, users can use the rayon crate defined parallel iterator methods over Vector scalar data with `into_par_iter`, `par_iter`, and `par_mut_iter`methods.

Implements the rayon `ParallelSlice` and `ParallelSliceMut` traits on the `Vector` type.  This supports the `as_parallel_slice` and `as_parallel_slice_mut` methods for use with the parallel iterators over slices defined in the rayon crate.